### PR TITLE
bgzip rs instead of rust htslib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.2.7", features = ["derive"] }
-rust-htslib = { version = "*", default-features = false }
 rayon = "1.7"
 num_cpus = "1.0"
+bgzip = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ clap = { version = "4.2.7", features = ["derive"] }
 rayon = "1.7"
 num_cpus = "1.0"
 bgzip = "0.3.1"
+file-format = "0.23.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,11 +30,9 @@
 /// or not. Extra threads help with compressing output and
 /// decompressing input.
 use clap::Parser;
-use std::process::ExitCode;
 use num_cpus;
 use std::path::Path;
-use file_format::FileFormat;
-
+use std::process::ExitCode;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -69,7 +67,7 @@ struct Args {
     keep_prefix: bool,
 
     /// Zip output files as BGZF format (not implemented)
-    #[arg(short, long, default_value_t = true)]
+    #[arg(short, long)]
     zip: bool,
 
     /// Threads to use
@@ -85,7 +83,6 @@ struct Args {
     verbose: bool,
 }
 
-
 fn is_readable(filename: &String) -> bool {
     use std::fs::File;
     let mut f = match File::open(&filename) {
@@ -99,7 +96,6 @@ fn is_readable(filename: &String) -> bool {
         Err(_) => false,
     }
 }
-
 
 fn main() -> ExitCode {
     let args = Args::parse();
@@ -120,8 +116,6 @@ fn main() -> ExitCode {
         .num_threads(args.threads as usize)
         .build_global()
         .unwrap();
-
-    let _format = FileFormat::from_file(&args.fastq);
 
     if args.verbose {
         eprintln!("input file: {}", args.fastq);
@@ -159,7 +153,7 @@ fn main() -> ExitCode {
         eprintln!("output file already exists: {}", args.out);
     }
 
-    use adapto_rs::process_reads;
+    use adapto_rs::remove_adaptors;
 
     if let (Some(pfastq), Some(pout)) = (args.pfastq, args.pout) {
         if !is_readable(&pfastq) {
@@ -169,7 +163,7 @@ fn main() -> ExitCode {
         if args.verbose && Path::new(&pout).exists() {
             eprintln!("output file already exists: {}", pout);
         }
-        match process_reads(
+        match remove_adaptors(
             args.zip,
             args.buffer_size,
             &adaptor,
@@ -177,12 +171,15 @@ fn main() -> ExitCode {
             &pout,
             args.qual_cutoff,
         ) {
-            Err(e) => eprintln!("error processing end two: {}", e),
-            _ => (),
+            Err(e) => {
+                eprintln!("error processing end two: {}", e);
+                return ExitCode::FAILURE;
+            },
+            Ok(_) => (),
         };
     }
 
-    match process_reads(
+    match remove_adaptors(
         args.zip,
         args.buffer_size,
         &adaptor,
@@ -190,10 +187,10 @@ fn main() -> ExitCode {
         &args.out,
         args.qual_cutoff,
     ) {
-        Err(err) => {
-            eprintln!("error processing end one: {}", err);
+        Err(e) => {
+            eprintln!("error processing end one: {}", e);
             ExitCode::FAILURE
-        }
+        },
         Ok(_) => ExitCode::SUCCESS
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ use clap::Parser;
 use std::process::ExitCode;
 use num_cpus;
 use std::path::Path;
+use file_format::FileFormat;
+
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -119,6 +121,8 @@ fn main() -> ExitCode {
         .build_global()
         .unwrap();
 
+    let _format = FileFormat::from_file(&args.fastq);
+
     if args.verbose {
         eprintln!("input file: {}", args.fastq);
         eprintln!("output file: {}", args.out);
@@ -167,7 +171,6 @@ fn main() -> ExitCode {
         }
         match process_reads(
             args.zip,
-            args.threads,
             args.buffer_size,
             &adaptor,
             &pfastq,
@@ -181,7 +184,6 @@ fn main() -> ExitCode {
 
     match process_reads(
         args.zip,
-        args.threads,
         args.buffer_size,
         &adaptor,
         &args.fastq,


### PR DESCRIPTION
- Cargo.toml: updating packages for bgzip
- Cargo.toml: adding file-format crate
- Removing the number of threads from args to process_reads as rayon should handle it
- lib.rs: switched to using bgzip instead of rust-htslib beause rust-htslib wasn't working
- main.rs: cleaning up
- lib.rs: separating the creation of readers and writers from their use, so that different types can be used; this is all from the fact that bgzip-rs does not allow to read uncompressed files or write without any compression headers
